### PR TITLE
Fix isinstance check in hm - allow 'bands' to be any integral type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ htmlcov
 
 # editors
 .vscode
+
+# Jupyter
+.ipynb_checkpoints

--- a/z2pack/hm.py
+++ b/z2pack/hm.py
@@ -4,6 +4,7 @@
 This module contains a class for creating Systems which are described by a Hamiltonian matrix (hm), such as k•p models.
 """
 
+import numbers
 import itertools
 
 import numpy as np
@@ -84,7 +85,7 @@ class System(EigenstateSystem):
             self._pos = [np.array(p) for p in pos]
         if bands is None:
             bands = size // 2
-        if isinstance(bands, int):
+        if isinstance(bands, numbers.Integral):
             self._bands = list(range(bands))
         else:
             self._bands = bands


### PR DESCRIPTION
Replace the `isinstance(bands, int)` in hm.py with
`isinstance(bands, numbers.Integral)` - this fixes an error where
passing e.g. a numpy int would crash the calculation.