### PR TITLE
hm System with non-orthogonal basis

### DIFF
--- a/z2pack/hm.py
+++ b/z2pack/hm.py
@@ -35,8 +35,8 @@ class System(EigenstateSystem):
     :param hermitian_tol:   Maximum absolute value in the difference between the Hamiltonian and its hermitian conjugate. Use ``hermitian_tol=None`` to deactivate the test entirely.
     :type hermitian_tol:    float
 
-    :param basis_overlaps: A function taking the wavevector ``k`` (``list`` of length 3) as an input and returning the overlap matrix.
-    :type overlap: collections.abc.Callable
+    :param basis_overlap: A function taking the wavevector ``k`` (``list`` of length 3) as an input and returning the overlap matrix between the basis vectors w.r.t which the Hamiltonian is defined. If no value is given, the basis is assumed to be orthonormal.
+    :type basis_overlap: collections.abc.Callable
 
     :param convention: The convention used for the Hamiltonian, following the `pythtb formalism <http://www.physics.rutgers.edu/pythtb/_downloads/pythtb-formalism.pdf>`_. Convention 1 means that the eigenvalues of :math:`\mathcal{H}(\mathbf{k})` are wave vectors :math:`\left|\psi_{n\mathbf{k}}\right>`. With convention 2, they are the cell-periodic Bloch functions :math:`\left|u_{n\mathbf{k}}\right>`.
     :type convention: int


### PR DESCRIPTION
Implemented handling of non-orthonal basis by `z2pack.hm.System`.

Added `_hamilton_orthogonal` property (bool) which is `True` is the Hamiltonian is orthogonal and `False` ortherwise.
Added `basis_overlaps` to store the function to call for the overlap matrix at each `k`
The orthogonalization of the Hamiltonian is performed by a Lodwin transformation at each `k`.

We should give credits to @juijan at #79 