### PR TITLE
Update interpolated GH workflows, pin ruamel.yaml version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: Continuous Integration
-
 on: [push, pull_request]
 jobs:
   docs:
@@ -11,29 +10,24 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-
     - name: Install apt dependencies
       run: |
         sudo apt update -qq
         sudo apt install -qq graphviz
-
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: pip-${{ matrix.python-version }}-${{ matrix.install-type }}-${{ hashFiles('**/setup.json')
           }}
         restore-keys: pip-${{ matrix.python-version }}-${{ matrix.install-type }}
-
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
     - name: Install the python project
       env:
         INSTALL_TYPE: ${{ matrix.install-type }}
       run: .ci/install_script.sh
-
     - name: Build documentation
       env:
         READTHEDOCS: 'True'
@@ -42,7 +36,6 @@ jobs:
       with:
         name: doc-build
         path: doc/build/html
-
   pre-commit:
     runs-on: ubuntu-latest
     strategy:
@@ -52,29 +45,24 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-
     - name: Install apt dependencies
       run: |
         sudo apt update -qq
         sudo apt install -qq graphviz
-
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: pip-${{ matrix.python-version }}-${{ matrix.install-type }}-${{ hashFiles('**/setup.json')
           }}
         restore-keys: pip-${{ matrix.python-version }}-${{ matrix.install-type }}
-
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
     - name: Install the python project
       env:
         INSTALL_TYPE: ${{ matrix.install-type }}
       run: .ci/install_script.sh
-
     - name: Run pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1
         )
@@ -92,29 +80,24 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-
     - name: Install apt dependencies
       run: |
         sudo apt update -qq
         sudo apt install -qq graphviz
-
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: pip-${{ matrix.python-version }}-${{ matrix.install-type }}-${{ hashFiles('**/setup.json')
           }}
         restore-keys: pip-${{ matrix.python-version }}-${{ matrix.install-type }}
-
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
     - name: Install the python project
       env:
         INSTALL_TYPE: ${{ matrix.install-type }}
       run: .ci/install_script.sh
-
     - name: Run pytest
       run: pytest --cov=z2pack --cov-config=.coveragerc
     - name: Run codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,4 +60,4 @@ dev =
     yapf==0.29
     pre-commit
     pylint==2.4.4
-    ruamel.yaml
+    ruamel.yaml==0.17.16


### PR DESCRIPTION
The change in the version of ruamel.yaml caused whitespace changes on the interpolated Github workflows. To avoid this in the future, the ruamel.yaml version in the dev dependencies is pinned.