### PR TITLE
Make Abinit Bi example run more quickly

### DIFF
--- a/examples/fp/abinit/Bi/Bi.py
+++ b/examples/fp/abinit/Bi/Bi.py
@@ -49,3 +49,13 @@ result_1 = z2pack.surface.run(
     save_file='./results/Bi_1.msgpack',
     load=True
 )
+print(
+    'Z2 topological invariant at kx = 0: {0}'.format(
+        z2pack.invariant.z2(result_0)
+    )
+)
+print(
+    'Z2 topological invariant at kx = 0.5: {0}'.format(
+        z2pack.invariant.z2(result_1)
+    )
+)

--- a/examples/fp/abinit/Bi/input/Bi_nscf.in
+++ b/examples/fp/abinit/Bi/input/Bi_nscf.in
@@ -1,21 +1,21 @@
-acell 3*4.7458 Angstrom 
+acell 3*4.7458 Angstrom
 angdeg 3*57.23338683919874
-ecut 80 
-enunit 2 
+ecut 50
+enunit 2
 natom 2
 nband 16
-nspinor 2 
-nsppol 1 
-ntypat 1 
+nspinor 2
+nsppol 1
+ntypat 1
 typat 1 1
 xred
-0.23389 0.23389 0.23389 
+0.23389 0.23389 0.23389
 -0.23389 -0.23389 -0.23389
 
-znucl 83.0 
+znucl 83.0
 
 iscf -2
-tolwfr 1e-21
+tolwfr 1e-10
 !irdwfk 1
 irdden 1
 prtwant 2

--- a/examples/fp/abinit/Bi/scf_input/Bi_scf.in
+++ b/examples/fp/abinit/Bi/scf_input/Bi_scf.in
@@ -1,23 +1,23 @@
-acell 3*4.7458 Angstrom 
+acell 3*4.7458 Angstrom
 angdeg 3*57.23338683919874
-ecut 80 
-enunit 2 
+ecut 50
+enunit 2
 natom 2
 nband 16
-nspinor 2 
-nsppol 1 
-nstep 100 
-ntypat 1 
+nspinor 2
+nsppol 1
+nstep 100
+ntypat 1
 typat 1 1
 xred
-0.23389 0.23389 0.23389 
+0.23389 0.23389 0.23389
 -0.23389 -0.23389 -0.23389
-znucl 83.0 
+znucl 83.0
 
 
-ngkpt 6 6 6 
-nshiftk 1 
+ngkpt 4 4 4
+nshiftk 1
 shiftk 0.5 0.5 0.5
-prtden 1 
-toldfe 1e-12 
-kptopt 1 
+prtden 1
+toldfe 1e-9
+kptopt 1


### PR DESCRIPTION
Reduce the k-point mesh and cut-off energy, and increase thresholds
in the Abinit Bi example.